### PR TITLE
Update to version 3.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update &&\
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions
 RUN cd /tmp &&\
   wget https://static.tp-link.com/2018/201811/20181108/Omada_Controller_v3.0.5_linux_x64.tar.gz.zip &&\
-  unzip Omada_Controller_v3.0.5_linux_x64.tar.gz.zip
-  tar zxvf Omada_Controller_v3.0.5_linux_x64.tar.gz
-  cd Omada_Controller_v3.0.5_linux_x64
+  unzip Omada_Controller_v3.0.5_linux_x64.tar.gz.zip &&\
+  tar zxvf Omada_Controller_v3.0.5_linux_x64.tar.gz &&\
+  cd Omada_Controller_v3.0.5_linux_x64 &&\
   mkdir /opt/tplink/EAPController -vp &&\
   cp bin /opt/tplink/EAPController -r &&\
   cp data /opt/tplink/EAPController -r &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN cd /tmp &&\
 
 USER omada
 WORKDIR /opt/tplink/EAPController
-EXPOSE 8088 8043
+EXPOSE 8043/tcp 8088/tcp 27001/udp 27002/tcp 29810/udp 29811/tcp 29812/tcp 29813/tcp
 VOLUME ["/opt/tplink/EAPController/data","/opt/tplink/EAPController/work","/opt/tplink/EAPController/logs"]
 CMD ["/opt/tplink/EAPController/jre/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:-UsePerfData","-Deap.home=/opt/tplink/EAPController","-cp","/opt/tplink/EAPController/lib/*:","com.tp_link.eap.start.EapLinuxMain"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 FROM ubuntu:18.04
-MAINTAINER Matt Bentley <mbentley@mbentley.net>
+MAINTAINER Christoph Eßer <christoph@cehser.de>
 
 # install runtime dependencies
 RUN apt-get update &&\
-  apt-get install -y libcap-dev net-tools wget &&\
+  apt-get install -y libcap-dev net-tools wget unzip &&\
   rm -rf /var/lib/apt/lists/*
 
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions
 RUN cd /tmp &&\
-  wget https://static.tp-link.com/2018/201809/20180907/Omada_Controller_V3.0.2_Linux_x64_targz.tar.gz &&\
-  tar zxvf Omada_Controller_V3.0.2_Linux_x64_targz.tar.gz &&\
-  cd Omada_Controller_V3.0.2_Linux_x64_targz &&\
+  wget https://static.tp-link.com/2018/201811/20181108/Omada_Controller_v3.0.5_linux_x64.tar.gz.zip &&\
+  unzip Omada_Controller_v3.0.5_linux_x64.tar.gz.zip
+  tar zxvf Omada_Controller_v3.0.5_linux_x64.tar.gz
+  cd Omada_Controller_v3.0.5_linux_x64
   mkdir /opt/tplink/EAPController -vp &&\
   cp bin /opt/tplink/EAPController -r &&\
   cp data /opt/tplink/EAPController -r &&\
@@ -24,7 +25,7 @@ RUN cd /tmp &&\
   chmod 755 /opt/tplink/EAPController/bin/* &&\
   chmod 755 /opt/tplink/EAPController/jre/bin/* &&\
   cd /tmp &&\
-  rm -rf /tmp/Omada_Controller_V3.0.2_Linux_x64_targz Omada_Controller_V3.0.2_Linux_x64_targz.tar.gz &&\
+  rm -rf /tmp/Omada_Controller_v3.0.5_linux_x64 Omada_Controller_v3.0.5_linux_x64.tar.gz.zip Omada_Controller_v3.0.5_linux_x64.tar.gz &&\
   groupadd -g 508 omada &&\
   useradd -u 508 -g 508 -d /opt/tplink/EAPController omada &&\
   mkdir /opt/tplink/EAPController/logs /opt/tplink/EAPController/work &&\

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Example usage:
 docker run -d --name omada-controller \
   -p 8043:8043/tcp 
   -p 8088:8088/tcp -
-  p 27001:27001/udp 
+  -p 27001:27001/udp 
   -p 27002:27002/tcp 
   -p 29810:29810/udp 
   -p 29811:29811/tcp 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
-mbentley/omada-controller
+ehseroffice/omada-controller
 =========================
 
 docker image for TP-Link Omada Controller
 based off of ubuntu:18.04
 
 To pull this image:
-`docker pull mbentley/omada-controller`
+`docker pull ehseroffice/omada-controller`
 
 Example usage:
 ```
 docker run -d --name omada-controller \
-  -p 8088:8088 \
-  -p 8043:8043 \
+  -p 8043:8043/tcp 
+  -p 8088:8088/tcp -
+  p 27001:27001/udp 
+  -p 27002:27002/tcp 
+  -p 29810:29810/udp 
+  -p 29811:29811/tcp 
+  -p 29812:29812/tcp 
+  -p 29813:29813/tcp
   -v omada-data:/opt/tplink/EAPController/data \
   -v omada-work:/opt/tplink/EAPController/work \
   -v omada-logs:/opt/tplink/EAPController/logs \
-  mbentley/omada-controller
+  ehseroffice/omada-controller
 ```


### PR DESCRIPTION
Omada uses even more ports which we should expose.

credits to: https://github.com/rbwsam/omada/blob/master/Dockerfile 
see also: https://www.tp-link.com/de/faq-1638.html