### PR TITLE
Disable MongoDB journaling

### DIFF
--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -31,6 +31,9 @@ RUN cd /tmp &&\
   mkdir /opt/tplink/EAPController/logs /opt/tplink/EAPController/work &&\
   chown -R omada:omada /opt/tplink/EAPController/data /opt/tplink/EAPController/logs /opt/tplink/EAPController/work
 
+# Disable MongoDB journaling
+RUN sed -i 's/linux.mongod.nojournal=false/linux.mongod.nojournal=true/g' /opt/tplink/EAPController/properties/mongodb.properties
+
 USER omada
 WORKDIR /opt/tplink/EAPController
 EXPOSE 8088 8043


### PR DESCRIPTION
Great job with that container! But this is the big missing feature, IMO.
By deafult, developers of Omada Controller had left jurnaling enabled, which causes it to consume gigabytes of disk space.