### PR TITLE
Add support for running on Raspberry Pi

### DIFF
--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -49,7 +49,11 @@ RUN echo "*** Replacing bundled versions ***" && \
   rm -f /opt/tplink/EAPController/bin/mongo && \
   ln -s /usr/bin/mongod /opt/tplink/EAPController/bin/mongo && \
   rm -rf /opt/tplink/EAPController/jre && \
-  ln -s /usr/lib/jvm/java-8-openjdk-arm64/jre /opt/tplink/EAPController/jre 
+  ln -s /usr/lib/jvm/java-8-openjdk-arm64/jre /opt/tplink/EAPController/jre
+
+# Remove mention of --nohttpinterface, which is not supported in MongoDB >= 3.6
+RUN echo "*** Fixing properties ***" &&\
+  sed -i -e 's/ --nohttpinterface//g' /opt/tplink/EAPController/properties/mongodb.properties
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -57,4 +57,4 @@ WORKDIR /opt/tplink/EAPController
 EXPOSE 8088 8043 27001/udp 27002 29810/udp 29811 29812 29813
 VOLUME ["/opt/tplink/EAPController/data","/opt/tplink/EAPController/work","/opt/tplink/EAPController/logs"]
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/opt/tplink/EAPController/jre/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:-UsePerfData","-Deap.home=/opt/tplink/EAPController","-cp","/opt/tplink/EAPController/lib/*:","com.tp_link.eap.start.EapLinuxMain"]
+CMD ["/opt/tplink/EAPController/jre/bin/java","-client","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:-UsePerfData","-Deap.home=/opt/tplink/EAPController","-cp","/opt/tplink/EAPController/lib/*:","com.tp_link.eap.start.EapLinuxMain"]

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -33,7 +33,6 @@ RUN \
   cp install.sh /opt/tplink/EAPController -r &&\
   cp uninstall.sh /opt/tplink/EAPController -r &&\
   chmod 755 /opt/tplink/EAPController/bin/* &&\
-  chmod 755 /opt/tplink/EAPController/jre/bin/* &&\
   echo "**** Cleanup ****" &&\
   cd /tmp &&\
   rm -rf /tmp/Omada_Controller* &&\

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -1,4 +1,5 @@
 FROM ubuntu:18.04
+HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
+HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # Install java

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -2,6 +2,14 @@ FROM ubuntu:18.04
 HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
+# Install java
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk
+
+# Install mongodb
+RUN apt-get update && \
+    apt-get install -y mongodb
+
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions
 RUN \
   echo "**** Install Dependencies ****" &&\
@@ -35,6 +43,15 @@ RUN \
   useradd -u 508 -g 508 -d /opt/tplink/EAPController omada &&\
   mkdir /opt/tplink/EAPController/logs /opt/tplink/EAPController/work &&\
   chown -R omada:omada /opt/tplink/EAPController/data /opt/tplink/EAPController/logs /opt/tplink/EAPController/work
+
+# Replace with installed versions
+RUN echo "*** Replacing bundled versions ***" && \
+  rm -f /opt/tplink/EAPController/bin/mongod && \
+  ln -s /usr/bin/mongod /opt/tplink/EAPController/bin/mongod && \
+  rm -f /opt/tplink/EAPController/bin/mongo && \
+  ln -s /usr/bin/mongod /opt/tplink/EAPController/bin/mongo && \
+  rm -rf /opt/tplink/EAPController/jre && \
+  ln -s /usr/lib/jvm/java-8-openjdk-arm64/jre /opt/tplink/EAPController/jre 
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -57,4 +57,4 @@ WORKDIR /opt/tplink/EAPController
 EXPOSE 8088 8043 27001/udp 27002 29810/udp 29811 29812 29813
 VOLUME ["/opt/tplink/EAPController/data","/opt/tplink/EAPController/work","/opt/tplink/EAPController/logs"]
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/opt/tplink/EAPController/jre/bin/java","-client","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:-UsePerfData","-Deap.home=/opt/tplink/EAPController","-cp","/opt/tplink/EAPController/lib/*:","com.tp_link.eap.start.EapLinuxMain"]
+CMD ["/opt/tplink/EAPController/jre/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:-UsePerfData","-Deap.home=/opt/tplink/EAPController","-cp","/opt/tplink/EAPController/lib/*:","com.tp_link.eap.start.EapLinuxMain"]

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -32,7 +32,6 @@ RUN \
   cp lib /opt/tplink/EAPController -r &&\
   cp install.sh /opt/tplink/EAPController -r &&\
   cp uninstall.sh /opt/tplink/EAPController -r &&\
-  cp jre /opt/tplink/EAPController/jre -r &&\
   chmod 755 /opt/tplink/EAPController/bin/* &&\
   chmod 755 /opt/tplink/EAPController/jre/bin/* &&\
   echo "**** Cleanup ****" &&\

--- a/Dockerfile.v3.2.x-arm64
+++ b/Dockerfile.v3.2.x-arm64
@@ -1,5 +1,14 @@
 FROM ubuntu:18.04
+HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
+
+# Install java (same version as Omada, as of 3.2.6)
+RUN apt-get update && \
+    apt-get install -y openjdk-8-jdk=8u162-b12-1
+
+# Install mongodb
+RUN apt-get update && \
+    apt-get install -y mongodb
 
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions
 RUN \
@@ -23,9 +32,7 @@ RUN \
   cp lib /opt/tplink/EAPController -r &&\
   cp install.sh /opt/tplink/EAPController -r &&\
   cp uninstall.sh /opt/tplink/EAPController -r &&\
-  cp jre /opt/tplink/EAPController/jre -r &&\
   chmod 755 /opt/tplink/EAPController/bin/* &&\
-  chmod 755 /opt/tplink/EAPController/jre/bin/* &&\
   echo "**** Cleanup ****" &&\
   cd /tmp &&\
   rm -rf /tmp/Omada_Controller* &&\
@@ -34,6 +41,19 @@ RUN \
   useradd -u 508 -g 508 -d /opt/tplink/EAPController omada &&\
   mkdir /opt/tplink/EAPController/logs /opt/tplink/EAPController/work &&\
   chown -R omada:omada /opt/tplink/EAPController/data /opt/tplink/EAPController/logs /opt/tplink/EAPController/work
+
+# Replace with installed versions
+RUN echo "*** Replacing bundled versions ***" && \
+  rm -f /opt/tplink/EAPController/bin/mongod && \
+  ln -s /usr/bin/mongod /opt/tplink/EAPController/bin/mongod && \
+  rm -f /opt/tplink/EAPController/bin/mongo && \
+  ln -s /usr/bin/mongod /opt/tplink/EAPController/bin/mongo && \
+  rm -rf /opt/tplink/EAPController/jre && \
+  ln -s /usr/lib/jvm/java-8-openjdk-arm64/jre /opt/tplink/EAPController/jre
+
+# Remove mention of --nohttpinterface, which is not supported in MongoDB >= 3.6
+RUN echo "*** Fixing properties ***" &&\
+  sed -i -e 's/ --nohttpinterface//g' /opt/tplink/EAPController/properties/mongodb.properties
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.v3.2.x-arm64
+++ b/Dockerfile.v3.2.x-arm64
@@ -4,7 +4,7 @@ MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # Install java (same version as Omada, as of 3.2.6)
 RUN apt-get update && \
-    apt-get install -y openjdk-8-jdk=8u162-b12-1
+    apt-get install -y openjdk-8-jre-headless=8u162-b12-1
 
 # Install mongodb
 RUN apt-get update && \

--- a/Dockerfile.v3.2.x-arm64
+++ b/Dockerfile.v3.2.x-arm64
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
+HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # Install java (same version as Omada, as of 3.2.6)

--- a/Dockerfile.v3.2.x-arm64
+++ b/Dockerfile.v3.2.x-arm64
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
+HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # Install java (same version as Omada, as of 3.2.6)


### PR DESCRIPTION
The bundled java and MongoDB binaries won't run on a Raspberry Pi. This PR installs the JDK and MongoDB, and links them into the EAP installation.

It also includes the previous PR adding a health check (mbentley/docker-omada-controller#22)

I've run this on a Raspberry Pi 3 with Ubuntu 18 64-bit as the host OS, and it works fine.