### PR TITLE
Set starting period to 5 minutes in health check

### DIFF
--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-HEALTHCHECK --start-period=15m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
+HEALTHCHECK --start-period=5m CMD wget --quiet --tries=1 --no-check-certificate http://127.0.0.1:8088 || exit 1
 MAINTAINER Matt Bentley <mbentley@mbentley.net>
 
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions


### PR DESCRIPTION
The "15m" wasn't changed to "5m" in mbentley/docker-omada-controller#22