### PR TITLE
Fixed typo (references to 5.1.17 -> 5.1.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following tags have multi-arch support for `amd64`, `armv7l`, and `arm64` an
 
 | Tag(s) | Major.Minor Release | Current Version |
 | :----- | ------------------- | --------------- |
-| `latest`, `5.1` | Omada Controller `5.1.x` | `5.1.17` |
+| `latest`, `5.1` | Omada Controller `5.1.x` | `5.1.7` |
 | `5.0` | Omada Controller `5.0.x` | `5.0.30` |
 | `4.4` | Omada Controller `4.4.x` | `4.4.8` |
 | `4.3` | Omada Controller `4.3.x` | `4.3.5` |


### PR DESCRIPTION
Addresses issue noticed in git commit message and in the README (https://github.com/mbentley/docker-omada-controller/pull/192#issuecomment-1075285069)

Signed-off-by: Matt Bentley <mbentley@mbentley.net>