### PR TITLE
Add image source label to container.

### DIFF
--- a/Dockerfile.v3.0.x
+++ b/Dockerfile.v3.0.x
@@ -1,6 +1,7 @@
 # rebased/repackaged base image that only updates existing packages
 FROM mbentley/ubuntu:18.04
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 ARG INSTALL_VER=3.0
 

--- a/Dockerfile.v3.1.x
+++ b/Dockerfile.v3.1.x
@@ -1,6 +1,7 @@
 # rebased/repackaged base image that only updates existing packages
 FROM mbentley/ubuntu:18.04
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 ARG INSTALL_VER=3.1
 

--- a/Dockerfile.v3.2.x
+++ b/Dockerfile.v3.2.x
@@ -1,6 +1,7 @@
 # rebased/repackaged base image that only updates existing packages
 FROM mbentley/ubuntu:18.04
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 ARG INSTALL_VER=3.2
 

--- a/Dockerfile.v3.2.x-arm64
+++ b/Dockerfile.v3.2.x-arm64
@@ -1,6 +1,7 @@
 # rebased/repackaged base image that only updates existing packages
 FROM mbentley/ubuntu:18.04
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 ARG INSTALL_VER=3.2
 

--- a/Dockerfile.v3.2.x-armv7l
+++ b/Dockerfile.v3.2.x-armv7l
@@ -1,6 +1,7 @@
 # rebased/repackaged base image that only updates existing packages
 FROM mbentley/ubuntu:16.04
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 ARG INSTALL_VER=3.2
 

--- a/Dockerfile.v4.x
+++ b/Dockerfile.v4.x
@@ -2,6 +2,7 @@
 ARG BASE=mbentley/ubuntu:18.04
 FROM ${BASE}
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 COPY healthcheck.sh install.sh log4j_patch.sh /
 

--- a/Dockerfile.v5.x
+++ b/Dockerfile.v5.x
@@ -2,6 +2,7 @@
 ARG BASE=mbentley/ubuntu:20.04
 FROM ${BASE}
 LABEL maintainer="Matt Bentley <mbentley@mbentley.net>"
+LABEL org.opencontainers.image.source="https://github.com/mbentley/docker-omada-controller"
 
 COPY healthcheck.sh install.sh log4j_patch.sh /
 


### PR DESCRIPTION
This allows services (such as [renovate](https://github.com/renovatebot/renovate)) to find the source and generate changelogs.

Not sure if this should also be added to other dockerfiles. 