### PR TITLE
update upgrade path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ As always, take backups and read the documentation but the quick explanation of 
 
 * `3.2` -> `4.1`
   * This is a manual upgrade. See [Upgrading to 4.1 from 3.2.10 or below](#upgrading-to-41-from-3210-or-below).
-* `4.1` -> `4.4` -> `5.0` -> `5.x` (latest)
+* `4.1` -> `5.x` (latest)
   * These are automatic upgrades that take place by updating the image tag.
 
 ## Upgrading to 5.0.x from 4.1.x or above


### PR DESCRIPTION
According to the latest Release Notes, it's enough to do 3.2 -> 4.1 -> 5.x upgrade path.

https://community.tp-link.com/en/business/forum/topic/589730

Notes, point 3):
> 3) If you are upgrading from controller v3.x, it's highly recommended to upgrade 3.x to v4.1.5 first, then v4.1.5 to the latest 5.x. Please follow the [Omada Controller Upgrade Guide](https://www.tp-link.com/omada-sdn/controller-upgrade/) in the installation package before upgrading.