### PR TITLE
Fix getting group ID

### DIFF
--- a/entrypoint-5.x.sh
+++ b/entrypoint-5.x.sh
@@ -47,7 +47,7 @@ if grep -q -E "^${PGROUP}:" /etc/group > /dev/null 2>&1
 then
   # existing group found; also make sure the omada group matches the GID
   echo "INFO: Group (${PGROUP}) exists; skipping creation"
-  EXISTING_GID="$(id -g "${PGROUP}")"
+  EXISTING_GID="$(getent group "${PGROUP}" | cut -d: -f3)"
   if [ "${EXISTING_GID}" != "${PGID}" ]
   then
     echo "ERROR: Group (${PGROUP}) has an unexpected GID; was expecting '${PGID}' but found '${EXISTING_GID}'!"


### PR DESCRIPTION
`id -g` expects a username as argument, not a group name, so this failed to get the GID in cases where the group name wasn't also a username.

## Before

```
$ podman run -e PUID=65534 -e PGID=65534 -e PUSERNAME=nobody -e PGROUP=nogroup docker.io/mbentley/omada-controller
INFO: Validating user/group (nobody:nogroup) exists with correct UID/GID (65534:65534)
INFO: Group (nogroup) exists; skipping creation
id: 'nogroup': no such user
```


## After

```
$ podman run -e PUID=65534 -e PGID=65534 -e PUSERNAME=nobody -e PGROUP=nogroup test
INFO: Validating user/group (nobody:nogroup) exists with correct UID/GID (65534:65534)
INFO: Group (nogroup) exists; skipping creation
INFO: User (nobody) exists; skipping creation
INFO: Time zone set to 'Etc/UTC'
INFO: Value of 'manage.http.port' already set to 8088 in omada.properties
INFO: Value of 'manage.https.port' already set to 8043 in omada.properties
INFO: Value of 'portal.http.port' already set to 8088 in omada.properties
INFO: Value of 'portal.https.port' already set to 8843 in omada.properties
INFO: Value of 'port.adopt.v1' already set to 29812 in omada.properties
INFO: Value of 'port.app.discovery' already set to 27001 in omada.properties
INFO: Value of 'port.upgrade.v1' already set to 29813 in omada.properties
INFO: Value of 'port.manager.v1' already set to 29811 in omada.properties
INFO: Value of 'port.manager.v2' already set to 29814 in omada.properties
INFO: Value of 'port.discovery' already set to 29810 in omada.properties
INFO: Value of 'port.transfer.v2' already set to 29815 in omada.properties
INFO: Value of 'port.rtty' already set to 29816 in omada.properties
INFO: Value of 'mongo.external' already set to false in omada.properties
INFO: Value of 'eap.mongod.uri' already set to mongodb://127.0.0.1:27217/omada in omada.properties
WARN: Ownership not set correctly on '/opt/tplink/EAPController/data'; setting correct ownership (nobody:nogroup)
WARN: Ownership not set correctly on '/opt/tplink/EAPController/logs'; setting correct ownership (nobody:nogroup)
WARN: Ownership not set correctly on '/opt/tplink/EAPController/properties'; setting correct ownership (nobody:nogroup)
INFO: Version check passed; image version (5.14.26.1) >= the last version ran (0.0.0); writing image version to last ran file...
INFO: userland/kernel check passed

##############################################################################
##############################################################################
WARNGING: autobackup directory not found! Please configure automatic backups!
  For instructions, see https://github.com/mbentley/docker-omada-controller#controller-backups
##############################################################################
##############################################################################

INFO: Starting Omada Controller as user nobody
[...]
```