### PR TITLE
Wikipedia timezone table columns changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ By default, Omada software uses self-signed certificates. If however you want to
 
 ## Time Zones
 
-By default, this image uses the `Etc/UTC` time zone. You may update the time zone used by passing a different value in the `TZ` variable. See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) for a complete list of values in the `TZ database name` table column.
+By default, this image uses the `Etc/UTC` time zone. You may update the time zone used by passing a different value in the `TZ` variable. See [List of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) for a complete list of values in the `TZ identifier` table column.
 
 ## Unprivileged Ports
 


### PR DESCRIPTION
Wikipedia timezone table columns changed, the identifier is now in `TZ identifier`, not `TZ database name` any more.