### PR TITLE
Added mongodb build arg; fixes #692

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ARG ARCH=amd64
 ARG INSTALL_VER="6.0.0.25"
 ARG NO_MONGODB=false
 
+# optional cache busting build arg (value is not actually used anywhere)
+ARG MONGODB_VER
+
 # install omada controller (instructions taken from install.sh)
 RUN /install.sh &&\
   rm /install.sh


### PR DESCRIPTION
* Adds an optional build arg to be used with cache busting

Example of how it would be used is with:

```
# manually specify
--build-arg MONGODB_VER=r8.0.17

# get the latest version of 8.0.x from github
--build-arg MONGODB_VER=$(wget -q --header="Accept: application/vnd.github+json" --header="X-GitHub-Api-Version: 2022-11-28" -O - "https://api.github.com/repos/mongodb/mongo/tags?per_page=100" | jq -r '.[].name' | grep -E '^r8[.]0[.][0-9]+$' | sort --version-sort -r | head -1)
```