### PR TITLE
Removed --add-opens ALL-UNNAMED JVM args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 8088 8043 8843 19810/udp 27001/udp 29810/udp 29811 29812 29813 29814 2981
 HEALTHCHECK --start-period=5m CMD /healthcheck.sh
 VOLUME ["/opt/tplink/EAPController/data","/opt/tplink/EAPController/logs"]
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","--add-opens","java.base/sun.security.x509=ALL-UNNAMED","--add-opens","java.base/sun.security.util=ALL-UNNAMED","-cp","/opt/tplink/EAPController/lib/*:/opt/tplink/EAPController/properties","com.tplink.smb.omada.starter.OmadaLinuxMain"]
+CMD ["java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*:/opt/tplink/EAPController/properties","com.tplink.smb.omada.starter.OmadaLinuxMain"]

--- a/entrypoint-unified.sh
+++ b/entrypoint-unified.sh
@@ -398,26 +398,6 @@ show_java_version() {
   echo -e "INFO: output of 'java -version':\n$(java -version 2>&1)\n"
 }
 
-handle_java_version() {
-  # get the java version in different formats
-  JAVA_VERSION="$(java -version 2>&1 | head -n 1 | awk -F '"' '{print $2}')"
-  JAVA_VERSION_1="$(echo "${JAVA_VERSION}" | awk -F '.' '{print $1}')"
-  JAVA_VERSION_2="$(echo "${JAVA_VERSION}" | awk -F '.' '{print $2}')"
-
-  # for java 8, remove the opens argument from the CMD
-  case ${JAVA_VERSION_1}.${JAVA_VERSION_2} in
-    1.8)
-      echo "INFO: running Java 8; removing '--add-opens' option(s) from CMD (if present)..."
-      # remove opens option from global EXEC_ARGS array
-      NEW_CMD="${EXEC_ARGS[*]}"
-      NEW_CMD="${NEW_CMD/'--add-opens java.base/sun.security.x509=ALL-UNNAMED '/}"
-      NEW_CMD="${NEW_CMD/'--add-opens java.base/sun.security.util=ALL-UNNAMED '/}"
-      # shellcheck disable=SC2206
-      EXEC_ARGS=(${NEW_CMD})
-      ;;
-  esac
-}
-
 inject_cloudsdk_jar() {
   # inject cloudsdk JAR at the beginning of the classpath to ensure correct certificate loads first
   # check if we're actually starting the Omada controller (not just running some other command)
@@ -780,7 +760,6 @@ common_setup_and_validation() {
   check_userland_kernel
   show_java_version
   warn_autobackup
-  handle_java_version
   patch_java_heap
   inject_cloudsdk_jar
 }


### PR DESCRIPTION
* This was fixed in the upstream controller 5.15.20.x per https://community.tp-link.com/en/business/forum/topic/710680
* Verified to be working as expected on the latest 5.15 and 6.2 tags