### PR TITLE
Fixed classpath shell expansion assumptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ WORKDIR /opt/tplink/EAPController/lib
 EXPOSE 8088 8043 8843 19810/udp 27001/udp 29810/udp 29811 29812 29813 29814 29815 29816 29817
 HEALTHCHECK --start-period=5m CMD /healthcheck.sh
 VOLUME ["/opt/tplink/EAPController/data","/opt/tplink/EAPController/logs"]
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*:/opt/tplink/EAPController/properties","com.tplink.smb.omada.starter.OmadaLinuxMain"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["/entrypoint.sh java -server -Xms128m -Xmx1024m -XX:MaxHeapFreeRatio=60 -XX:MinHeapFreeRatio=30 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof -Djava.awt.headless=true -cp /opt/tplink/EAPController/lib/*:/opt/tplink/EAPController/properties com.tplink.smb.omada.starter.OmadaLinuxMain"]


### PR DESCRIPTION
Dockerfile incorrectly assumed that the container ENTRYPOINT/CMD would be executed by a shell which supports glob/wildcard expansion. This has been resolved by explicitly invoking bash

Resolves #550

---

Note that due to the change in ENTRYPOINT/CMD this will be a breaking change for anyone who is currently overriding the CMD for their containers.